### PR TITLE
fix for requesting >209 account names

### DIFF
--- a/NadeoServices.as
+++ b/NadeoServices.as
@@ -142,6 +142,7 @@ namespace NadeoServices
 		auto userMgr = GetApp().UserManagerScript;
 		auto userId = userMgr.Users[0].Id;
 
+		uint idLimit = 209;
 		dictionary ret;
 
 		array<string> missing;
@@ -155,9 +156,14 @@ namespace NadeoServices
 			}
 		}
 
-		if (missing.Length > 0) {
+		if (missing.Length == 0) {
+			return ret;
+		}
+
+		while (true) {
 			MwFastBuffer<wstring> ids;
-			for (uint i = 0; i < missing.Length; i++) {
+			uint idsToAdd = Math::Min(missing.Length, idLimit);
+			for (uint i = 0; i < idsToAdd; i++) {
 				ids.Add(missing[i]);
 			}
 
@@ -167,11 +173,17 @@ namespace NadeoServices
 			}
 			userMgr.TaskResult_Release(req.Id);
 
-			for (uint i = 0; i < missing.Length; i++) {
+			for (uint i = 0; i < idsToAdd; i++) {
 				string accountId = missing[i];
 				string displayName = userMgr.FindDisplayName(accountId);
 				ret.Set(accountId, displayName);
 			}
+
+			if (missing.Length <= idLimit) {
+				return ret;
+			}
+
+			missing.RemoveRange(0, idLimit);
 		}
 
 		return ret;

--- a/NadeoServices.as
+++ b/NadeoServices.as
@@ -156,11 +156,7 @@ namespace NadeoServices
 			}
 		}
 
-		if (missing.Length == 0) {
-			return ret;
-		}
-
-		while (true) {
+		while (missing.Length > 0) {
 			MwFastBuffer<wstring> ids;
 			uint idsToAdd = Math::Min(missing.Length, idLimit);
 			for (uint i = 0; i < idsToAdd; i++) {
@@ -179,11 +175,7 @@ namespace NadeoServices
 				ret.Set(accountId, displayName);
 			}
 
-			if (missing.Length <= idLimit) {
-				return ret;
-			}
-
-			missing.RemoveRange(0, idLimit);
+			missing.RemoveRange(0, idsToAdd);
 		}
 
 		return ret;


### PR DESCRIPTION
When requesting account names for more than 209 account IDs, the request fails without warning, returning a dictionary of account IDs and empty names. This fix makes one request per 209 accounts until they are exhausted.